### PR TITLE
新增预览构建的工作流，便于团队在线审阅PR

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,29 @@
+name: PR Preview Cleanup
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          
+      - name: Remove PR preview
+        run: |
+          if [ -d "pr-preview/pr-${{ github.event.pull_request.number }}" ]; then
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            rm -rf pr-preview/pr-${{ github.event.pull_request.number }}
+            git add -A
+            git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}"
+            git push origin gh-pages
+            echo "Cleaned up preview for PR #${{ github.event.pull_request.number }}"
+          else
+            echo "No preview found for PR #${{ github.event.pull_request.number }}"
+          fi

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,92 @@
+name: PR Preview
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0  # 获取完整Git历史
+          
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          
+      - name: Build the project
+        run: |
+          # 设置Git用户信息以避免RSS插件错误
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          mkdocs build --site-dir site
+
+      - name: Deploy PR Preview to gh-pages
+        run: |
+          # 切换到gh-pages分支
+          git fetch origin gh-pages
+          git checkout gh-pages
+          
+          # 创建PR预览目录
+          mkdir -p pr-preview/pr-${{ github.event.pull_request.number }}
+          rm -rf pr-preview/pr-${{ github.event.pull_request.number }}/*
+          cp -r site/* pr-preview/pr-${{ github.event.pull_request.number }}/
+          
+          # 提交更改
+          git add pr-preview/pr-${{ github.event.pull_request.number }}
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "PR #${{ github.event.pull_request.number }} preview"
+            git push origin gh-pages
+          fi
+
+      - name: Comment PR Preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = `🚀 PR 预览已部署：[点击查看](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.pull_request.number }}/)
+            
+            📝 预览将在PR关闭后自动清理`;
+            
+            // 检查是否已有预览评论
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const existingComment = comments.data.find(comment => 
+              comment.user.login === 'github-actions[bot]' && 
+              comment.body.includes('PR 预览已部署')
+            );
+            
+            if (existingComment) {
+              // 更新现有评论
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: comment
+              });
+            } else {
+              // 创建新评论
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment
+              });
+            }

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /pr-preview/


### PR DESCRIPTION
每当收到PR时，构建一份预览链接并粘贴于评论区，即使PR在合并前更新，也能够同步更新预览；

PR合并或直接关闭将会移除预览产物（预览链接失效），节省 GitHub Pages 资源。

<img width="844" alt="image" src="https://github.com/user-attachments/assets/cfdf0f06-b40d-4669-9d83-8b6783539b24" />
