### PR TITLE
docs: 增加 MIT18.01 (2006/2007) 与 MIT18.02 (2007) 课程条目

### DIFF
--- a/docs/academic-resources/math/learning-resources.md
+++ b/docs/academic-resources/math/learning-resources.md
@@ -21,8 +21,20 @@
     - 课程链接：[https://ocw.aca.ntu.edu.tw/courses/104S115](https://ocw.aca.ntu.edu.tw/courses/104S115)
 
 - **《分析》（复变、实变、测度论、泛函）**
+  
     - 作者：齐震宇（台大数学系助理教授）
+    
     - 课程链接：[https://ocw.aca.ntu.edu.tw/courses/105S107](https://ocw.aca.ntu.edu.tw/courses/105S107)
+    
+- **《MIT18.01 单变量微积分》**
+    - 作者：[David Jerison 教授](https://ocw.mit.edu/search/?q=Prof.+David+Jerison)
+    - 官方：[Single Variable Calculus | Mathematics | MIT OpenCourseWare](https://ocw.mit.edu/courses/18-01-single-variable-calculus-fall-2006/)
+    - 视频链接：[https://www.bilibili.com/video/BV1uavveaED9](https://www.bilibili.com/video/BV1uavveaED9)
+    
+- **《MIT18.02 多变量微积分》**
+    - 作者：[Denis Auroux 教授](https://ocw.mit.edu/search/?q=Prof.+Denis+Auroux)
+    - 官方：[Multivariable Calculus | Mathematics | MIT OpenCourseWare](https://ocw.mit.edu/courses/18-02-multivariable-calculus-fall-2007/)
+    - 视频链接：[https://www.bilibili.com/video/BV1PKaDe9ETw](https://www.bilibili.com/video/BV1PKaDe9ETw)
 
 ---
 


### PR DESCRIPTION
### 新增内容
在数学学习资源文档中，补充了两门经典的 MIT 微积分课程：
 - MIT18.01 单变量微积分 (Fall 2006, 2007)
 - MIT18.02 多变量微积分 (Fall 2007)

### 变更文件
- `docs\academic-resources\math\learning-resources.md`

### 链接预览
- [MIT18.01 单变量微积分 (2006/2007)](https://ocw.mit.edu/courses/18-01-single-variable-calculus-fall-2006/)
- [MIT18.02 多变量微积分 (2007)](https://ocw.mit.edu/courses/18-02-multivariable-calculus-fall-2007/)
